### PR TITLE
Add Late Execution

### DIFF
--- a/SCVE.Editor/ImGuiUi/ImGuiAssetRenderer.cs
+++ b/SCVE.Editor/ImGuiUi/ImGuiAssetRenderer.cs
@@ -15,8 +15,8 @@ namespace SCVE.Editor.ImGuiUi
         private ProjectPanelService _projectPanelService;
 
         public ImGuiAssetRenderer(
-            PreviewService previewService, 
-            EditingService editingService, 
+            PreviewService previewService,
+            EditingService editingService,
             ProjectPanelService projectPanelService)
         {
             _previewService = previewService;
@@ -41,7 +41,7 @@ namespace SCVE.Editor.ImGuiUi
                             fileIconTextureData.Height), "FileIcon");
 
                 fileIcon.ToGpu();
-                _previewService.SetPreviewImage(fileIcon);
+                EditorApp.Late("load preview image", () => { _previewService.SetPreviewImage(fileIcon); });
             }
 
             if (elementExpanded)
@@ -58,9 +58,11 @@ namespace SCVE.Editor.ImGuiUi
             if (ImGui.IsItemHovered() && ImGui.IsMouseDoubleClicked(ImGuiMouseButton.Left))
             {
                 // _assetPreviewModalPanel.SetOpenedAsset(sequenceAsset);
-
-                _editingService.SetOpenedSequence(asset.Content);
-                _previewService.SwitchSequence(asset.Content);
+                EditorApp.Late("open sequence", () =>
+                {
+                    _editingService.SetOpenedSequence(asset.Content);
+                    _previewService.SwitchSequence(asset.Content);
+                });
             }
 
             if (elementExpanded)

--- a/SCVE.Editor/ImGuiUi/MainMenuBar.cs
+++ b/SCVE.Editor/ImGuiUi/MainMenuBar.cs
@@ -35,14 +35,15 @@ namespace SCVE.Editor.ImGuiUi
         private FilePickerModalPanel _openProjectFilePickerModalPanel;
         private FilePickerModalPanel _addImageFilePickerModalPanel;
 
-        public MainMenuBar(PreviewService previewService,
+        public MainMenuBar(
+            PreviewService previewService,
             EditingService editingService,
             ModalManagerService modalManagerService,
             RecentsService recentsService,
             ProjectPanelService projectPanelService,
             BackgroundJobRunner backgroundJobRunner,
-            ClipEvaluator evaluator, 
-            ProjectLoaderService projectLoaderService, 
+            ClipEvaluator evaluator,
+            ProjectLoaderService projectLoaderService,
             ImageLoaderService imageLoaderService)
         {
             _previewService = previewService;
@@ -87,17 +88,20 @@ namespace SCVE.Editor.ImGuiUi
 
                                 if (ImGui.MenuItem(fileName, File.Exists(recent)))
                                 {
-                                    var videoProject = Utils.ReadJson<VideoProject>(recent);
+                                    EditorApp.Late("open project", () =>
+                                    {
+                                        var videoProject = Utils.ReadJson<VideoProject>(recent);
 
-                                    _editingService.SetOpenedProject(videoProject, recent);
-                                    _recentsService.NoticeOpen(recent);
-                                    _projectPanelService.ChangeLocation("/");
-                                    _previewService.SyncVisiblePreview();
+                                        _editingService.SetOpenedProject(videoProject, recent);
+                                        _recentsService.NoticeOpen(recent);
+                                        _projectPanelService.ChangeLocation("/");
+                                        _previewService.SyncVisiblePreview();
 
-                                    Console.WriteLine($"Loaded Recent Project: {videoProject.Title}");
+                                        Console.WriteLine($"Loaded Recent Project: {videoProject.Title}");
+                                    });
 
                                     // NOTE: break is needed, because _recentsService.NoticeOpen() modifies original list
-                                    break;
+                                    // break;
                                 }
 
                                 ShowHint(recent);
@@ -211,7 +215,8 @@ namespace SCVE.Editor.ImGuiUi
                         location: _projectPanelService.CurrentLocation,
                         content: image
                     );
-                    _editingService.OpenedProject.AddImage(imageAsset);
+
+                    EditorApp.Late("add image", () => { _editingService.OpenedProject.AddImage(imageAsset); });
                 }
             }
         }
@@ -233,16 +238,22 @@ namespace SCVE.Editor.ImGuiUi
                     {
                         Console.WriteLine("Loading new project, while there is a loaded one");
                     }
-                    _editingService.SetOpenedProject(videoProject, path);
-                    _recentsService.NoticeOpen(path);
-                    _projectPanelService.ChangeLocation("/");
-                    _previewService.SyncVisiblePreview();
+
+                    EditorApp.Late("open project", () =>
+                    {
+                        _editingService.SetOpenedProject(videoProject, path);
+                        _recentsService.NoticeOpen(path);
+                        _projectPanelService.ChangeLocation("/");
+                        _previewService.SyncVisiblePreview();
+                    });
                 }
             }
         }
 
         // This is a direct port of imgui_demo.cpp HelpMarker function
+
         // https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp#L190
+
         private void ShowHint(string message)
         {
             // ImGui.TextDisabled("(?)");

--- a/SCVE.Editor/ImGuiUi/Panels/ClipEffectsPanel.cs
+++ b/SCVE.Editor/ImGuiUi/Panels/ClipEffectsPanel.cs
@@ -82,8 +82,11 @@ namespace SCVE.Editor.ImGuiUi.Panels
                             var effect = Activator.CreateInstance(AllKnownEffects[i]) as EffectBase;
 
                             effect!.Updated += OnEffectUpdated;
-                            clip.Effects.Add(effect);
-                            _previewService.InvalidateRange(clip.StartFrame, clip.FrameLength);
+                            EditorApp.Late("add effect", () =>
+                            {
+                                clip.Effects.Add(effect);
+                                _previewService.InvalidateRange(clip.StartFrame, clip.FrameLength);
+                            });
                         }
                     }
 
@@ -104,7 +107,7 @@ namespace SCVE.Editor.ImGuiUi.Panels
                     // clip.Effects[_lastSelectedEffect].Updated -= OnEffectOnUpdated;
                     // clip.RemoveEffect(_lastSelectedEffect);
                     _lastSelectedEffect = -1;
-                    _previewService.InvalidateRange(clip.StartFrame, clip.FrameLength);
+                    EditorApp.Late("delete effect", () => { _previewService.InvalidateRange(clip.StartFrame, clip.FrameLength); });
                 }
             }
 

--- a/SCVE.Editor/ImGuiUi/Panels/FolderCreationPanel.cs
+++ b/SCVE.Editor/ImGuiUi/Panels/FolderCreationPanel.cs
@@ -17,14 +17,14 @@ namespace SCVE.Editor.ImGuiUi.Panels
         }
 
         private string _name = "";
-        
+
         public override void OnImGuiRender()
         {
             if (IsOpen)
             {
                 ImGui.OpenPopup(Name);
             }
-            
+
             // Checks if the popup modal "New Folder" is opened.
             if (ImGui.BeginPopupModal(Name, ref IsOpen))
             {
@@ -44,8 +44,11 @@ namespace SCVE.Editor.ImGuiUi.Panels
                             content: new Folder()
                         );
 
-                        _editingService.AddFolder(folderAsset);
-                        _projectPanelService.RescanCurrentLocation();
+                        EditorApp.Late("add folder", () =>
+                        {
+                            _editingService.AddFolder(folderAsset);
+                            _projectPanelService.RescanCurrentLocation();
+                        });
 
                         ImGui.CloseCurrentPopup();
                         Close();

--- a/SCVE.Editor/ImGuiUi/Panels/ProjectCreationPanel.cs
+++ b/SCVE.Editor/ImGuiUi/Panels/ProjectCreationPanel.cs
@@ -72,10 +72,13 @@ namespace SCVE.Editor.ImGuiUi.Panels
                         Utils.WriteJson(videoProject, projectPath);
                         Console.WriteLine($"Created project {_title}");
 
-                        _editingService.SetOpenedProject(videoProject);
+                        EditorApp.Late("open project", () =>
+                        {
+                            _editingService.SetOpenedProject(videoProject);
 
-                        _recentsService.NoticeOpen(projectPath);
-                        _projectPanelService.ChangeLocation("/");
+                            _recentsService.NoticeOpen(projectPath);
+                            _projectPanelService.ChangeLocation("/");
+                        });
 
                         ImGui.CloseCurrentPopup();
                         Close();

--- a/SCVE.Editor/ImGuiUi/Panels/ProjectPanel.cs
+++ b/SCVE.Editor/ImGuiUi/Panels/ProjectPanel.cs
@@ -109,14 +109,15 @@ namespace SCVE.Editor.ImGuiUi.Panels
                     {
                         _modalManagerService.OpenSequenceCreationPanel();
                     }
-                    
+
                     if (ImGui.MenuItem("Folder"))
                     {
                         _modalManagerService.OpenFolderCreationPanel();
                     }
-                    
+
                     ImGui.EndMenu();
                 }
+
                 ImGui.EndMenuBar();
             }
 
@@ -130,7 +131,7 @@ namespace SCVE.Editor.ImGuiUi.Panels
             {
                 if (ImGui.Button("<-"))
                 {
-                    _projectPanelService.LevelUp();
+                    EditorApp.Late("level up location", () => { _projectPanelService.LevelUp(); });
                 }
             }
 

--- a/SCVE.Editor/ImGuiUi/Panels/SequenceCreationPanel.cs
+++ b/SCVE.Editor/ImGuiUi/Panels/SequenceCreationPanel.cs
@@ -55,16 +55,16 @@ namespace SCVE.Editor.ImGuiUi.Panels
             if (ImGui.DragInt("FPS", ref _fps, 0.1f, 10, 120))
             {
             }
-            
+
             if (ImGui.DragInt("Frame length", ref _frameLength, 0.1f, 10, 60))
             {
             }
-            
+
             if (ImGui.DragInt("Resolution", ref _resolution, 0.1f, 10, 120))
             {
             }
         }
-        
+
 
         private void DrawControls()
         {
@@ -72,15 +72,18 @@ namespace SCVE.Editor.ImGuiUi.Panels
             {
                 if (_name != string.Empty)
                 {
-                    var sequenceAsset = SequenceAsset.CreateNew(
-                        name: _name,
-                        location: _projectPanelService.CurrentLocation,
-                        content: Sequence.CreateNew(30, new ScveVector2I(1280, 720), 150)
-                    );
+                    EditorApp.Late("create sequence asset", () =>
+                    {
+                        var sequenceAsset = SequenceAsset.CreateNew(
+                            name: _name,
+                            location: _projectPanelService.CurrentLocation,
+                            content: Sequence.CreateNew(30, new ScveVector2I(1280, 720), 150)
+                        );
 
-                    _editingService.AddSequence(sequenceAsset);
-                    _projectPanelService.RescanCurrentLocation();
-
+                        _editingService.AddSequence(sequenceAsset);
+                        _projectPanelService.RescanCurrentLocation();
+                    });
+                    
                     ImGui.CloseCurrentPopup();
                     Close();
                 }

--- a/SCVE.Editor/ImGuiUi/Panels/SettingsModalPanel.cs
+++ b/SCVE.Editor/ImGuiUi/Panels/SettingsModalPanel.cs
@@ -101,8 +101,11 @@ namespace SCVE.Editor.ImGuiUi.Panels
 
             if (ImGui.Button("Apply"))
             {
-                _settingsService.ApplySettings(_draftSettings);
-                Console.WriteLine("Settings have been applied.");
+                EditorApp.Late("apply settings", () =>
+                {
+                    _settingsService.ApplySettings(_draftSettings);
+                    Console.WriteLine("Settings have been applied.");
+                });
             }
 
             ImGui.SameLine();

--- a/SCVE.Editor/ImGuiUi/Services/SequencePanelPainterService.cs
+++ b/SCVE.Editor/ImGuiUi/Services/SequencePanelPainterService.cs
@@ -52,21 +52,6 @@ namespace SCVE.Editor.ImGuiUi.Services
         {
             _settingsService = settingsService;
             _clipRenderer = new ClipImGuiRenderer();
-            // _cursorShapePoints = new[]
-            // {
-            //     // top-left
-            //     new Vector2(),
-            //     // top-right
-            //     new(Settings.Instance.CursorSize.X, 0),
-            //     // right mid
-            //     new(Settings.Instance.CursorSize.X,
-            //         Settings.Instance.CursorSize.Y / 2f),
-            //     // bottom mid
-            //     new(Settings.Instance.CursorSize.X / 2, Settings.Instance.CursorSize.Y),
-            //     // left mid
-            //     new(0, Settings.Instance.CursorSize.Y / 2f),
-            // };
-            // _cursorCurrentPoints = new Vector2[_cursorShapePoints.Length];
         }
 
         public void SetRenderData(int cursorDragFrames, int cursorFrame, Sequence sequence)

--- a/SCVE.Editor/SCVE.Editor.csproj
+++ b/SCVE.Editor/SCVE.Editor.csproj
@@ -29,4 +29,11 @@
       <ProjectReference Include="..\SCVE.Engine.ImageSharpBindings\SCVE.Engine.ImageSharpBindings.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Remove="UiActions\UiActionBase.cs" />
+      <Compile Remove="Services\UiContextService.cs" />
+      <Compile Remove="Abstractions\IBeforeFrameRenderReceiver.cs" />
+      <Compile Remove="Abstractions\IAfterFrameRenderReceiver.cs" />
+    </ItemGroup>
+
 </Project>

--- a/SCVE.Editor/Services/FileDropReceiverService.cs
+++ b/SCVE.Editor/Services/FileDropReceiverService.cs
@@ -47,12 +47,16 @@ namespace SCVE.Editor.Services
 
                     var project = _projectLoaderService.Load(path);
 
-                    _editingService.SetOpenedProject(project, path);
-                    _recentsService.NoticeOpen(path);
-                    _projectPanelService.ChangeLocation("/");
-                    _previewService.SyncVisiblePreview();
+                    EditorApp.Late("open project", () =>
+                    {
+                        _editingService.SetOpenedProject(project, path);
+                        _recentsService.NoticeOpen(path);
+                        _projectPanelService.ChangeLocation("/");
+                        _previewService.SyncVisiblePreview();
 
-                    Console.WriteLine($"Loaded project {project.Title}");
+                        Console.WriteLine($"Loaded project {project.Title}");
+                    });
+
                     break;
                 }
             }
@@ -76,10 +80,15 @@ namespace SCVE.Editor.Services
                             location: _projectPanelService.CurrentLocation,
                             content: image
                         );
-                        _editingService.OpenedProject.AddImage(imageAsset);
 
-                        _projectPanelService.RescanCurrentLocation();
-                        Console.WriteLine($"Loaded image {fileName}");
+                        EditorApp.Late("add image", () =>
+                        {
+                            _editingService.OpenedProject.AddImage(imageAsset);
+
+                            _projectPanelService.RescanCurrentLocation();
+
+                            Console.WriteLine($"Loaded image {fileName}");
+                        });
                     }
                 }
             }

--- a/SCVE.Editor/Services/PlaybackService.cs
+++ b/SCVE.Editor/Services/PlaybackService.cs
@@ -54,15 +54,20 @@ namespace SCVE.Editor.Services
 
                 if (deltaFrames != 0)
                 {
-                    _editingService.CursorFrame += deltaFrames;
-                    if (_editingService.CursorFrame >= _editingService.OpenedSequence.FrameLength)
+                    int cursorFrame = _editingService.CursorFrame + deltaFrames;
+                    if (cursorFrame >= _editingService.OpenedSequence.FrameLength)
                     {
-                        _editingService.CursorFrame = 0;
+                        cursorFrame = 0;
                         Stop();
                     }
 
                     _timeAccumulator -= deltaFrames * msPerFrame;
-                    _previewService.SyncVisiblePreview();
+
+                    EditorApp.Late("playback sync", () =>
+                    {
+                        _editingService.CursorFrame = cursorFrame;
+                        _previewService.SyncVisiblePreview();
+                    });
                 }
             }
         }


### PR DESCRIPTION
So, because our UI state must be immutable during the rendering, I add late execution, so model changes appear after all panels have finished rendering. This helps with model consistency. 
There is a small catch. Lambda do allocate on the heap, so GC is under pressure with this change. But I monitored, there aren't too much these calls.

Note for further usage. Everything that is not changing UI state (loading, calculations etc.) Should be out of `.Late` so the code readability is concise.